### PR TITLE
fix ('git-push-tag' action): use inputs.repositoryUrl variable for remote

### DIFF
--- a/.github/actions/git-push-tag/action.yml
+++ b/.github/actions/git-push-tag/action.yml
@@ -17,8 +17,7 @@ runs:
   - name: Push tag
     shell: bash
     run: |-
-      git push -u --verbose --tags ${{ inputs.repositoryUrl }}
-      git push -u --verbose --follow-tags ${{ inputs.repositoryUrl }} ${{ inputs.mergeBranch }}
+      git push -u --verbose --tags ${{ inputs.repositoryUrl }} ${{ inputs.mergeBranch }}
   - name: Create Pull Request
     shell: bash
     run: |-

--- a/.github/actions/git-push-tag/action.yml
+++ b/.github/actions/git-push-tag/action.yml
@@ -17,8 +17,8 @@ runs:
   - name: Push tag
     shell: bash
     run: |-
-      git push --verbose --tags ${{ inputs.description }}
-      git push --verbose --follow-tags ${{ inputs.description }} ${{ inputs.mergeBranch }}
+      git push -u --verbose --tags ${{ inputs.repositoryUrl }}
+      git push -u --verbose --follow-tags ${{ inputs.repositoryUrl }} ${{ inputs.mergeBranch }}
   - name: Create Pull Request
     shell: bash
     run: |-


### PR DESCRIPTION
- fix ('git-push-tag' action): use correct variable 'inputs.repositoryUrl' for remote
- refactor ('git-push-tag' action): only use push --tags, remove push --follow-tags
