### PR TITLE
fix ('git-push-tag' action): prefix condition value inputs.dry-run with $

### DIFF
--- a/.github/actions/git-push-tag/action.yml
+++ b/.github/actions/git-push-tag/action.yml
@@ -24,7 +24,7 @@ runs:
     env:
       GH_TOKEN: ${{ github.token }}
     run: |-
-      $dryrun = @(if (${{ inputs.dry-run }}) {echo '--dry-run'} else {echo ''})
+      $dryrun = if ($${{ inputs.dry-run }}) {'--dry-run'} else {''}
       Write-Output "dryrun: $dryrun"
 
       Push-Location ${{ inputs.path }}


### PR DESCRIPTION
reason: $true and $false can be evaluated in Powershell
