### PR TITLE
refactor ('git-push-tag' action): leave variable $dryrun unassigned (null) when ${{inputs.dry-run}} is false

### DIFF
--- a/.github/actions/git-push-tag/action.yml
+++ b/.github/actions/git-push-tag/action.yml
@@ -24,7 +24,9 @@ runs:
     env:
       GH_TOKEN: ${{ github.token }}
     run: |-
-      $dryrun = ($${{ inputs.dry-run }}) ? '--dry-run' : ''
+      if ($${{ inputs.dry-run }})
+        $dryrun = '--dry-run'
+
       Write-Output "dryrun: $dryrun"
 
       Push-Location ${{ inputs.path }}


### PR DESCRIPTION
reason: assigning an empty string results in an empty passed as argument,
        which in turn results in failure
