### PR TITLE
refactor ('git-push-tag' action): use simple if/else instead of variable for `dryrun`

### DIFF
--- a/.github/actions/git-push-tag/action.yml
+++ b/.github/actions/git-push-tag/action.yml
@@ -24,15 +24,20 @@ runs:
     env:
       GH_TOKEN: ${{ github.token }}
     run: |-
-      if (${{ inputs.dry-run }})
-      {
-        $dryrun = '--dry-run'
-      }
-
-      Write-Output "dryrun: $dryrun"
+      $do_dryrun = ${{ inputs.dry-run }}
+      Write-Output "dryrun: $do_dryrun"
 
       Push-Location ${{ inputs.path }}
-      git push --force-with-lease --verbose $dryrun ${{ inputs.remote }} ${{ inputs.branch }}
-      git push --force-with-lease --verbose $dryrun --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
-      git push --force-with-lease --verbose $dryrun --tags ${{ inputs.remote }}
+      if ($do_dryrun == true)
+      {
+        git push --force-with-lease --verbose --dry-run ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose --dry-run --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose --dry-run --tags ${{ inputs.remote }}
+      }
+      else
+      {
+        git push --force-with-lease --verbose           ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose           --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose           --tags ${{ inputs.remote }}
+      }
       Pop-Location


### PR DESCRIPTION
reason: avoid dryrun _not_ working at all costs.

explainer: in the previous implementation, the variable $dryrun was only valid
           within the scope it was set in,
           resulting in it being invalid and thus null when calling `git push`.

This bug resulted in ~25 tags and packages being pushed to NuGet and GitHub registry.
