### PR TITLE
refactor ('git-push-tag' action): merge conditional steps back into one and use string comparison

### DIFF
--- a/.github/actions/git-push-tag/action.yml
+++ b/.github/actions/git-push-tag/action.yml
@@ -19,25 +19,25 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Push tag (dry run)
-    if: ${{ inputs.dry-run == true }}
+  - name: Push tag
     shell: pwsh
     env:
       GH_TOKEN: ${{ github.token }}
     run: |-
+      $do_dryrun = ("${{ inputs.dry-run }}" -eq "true")
+      Write-Output "dryrun: $do_dryrun"
+
       Push-Location ${{ inputs.path }}
-      git push --force-with-lease --verbose --dry-run ${{ inputs.remote }} ${{ inputs.branch }}
-      git push --force-with-lease --verbose --dry-run --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
-      git push --force-with-lease --verbose --dry-run --tags ${{ inputs.remote }}
-      Pop-Location
-  - name: Push tag (for real)
-    if: ${{ inputs.dry-run == false }}
-    shell: pwsh
-    env:
-      GH_TOKEN: ${{ github.token }}
-    run: |-
-      Push-Location ${{ inputs.path }}
-      git push --force-with-lease --verbose           ${{ inputs.remote }} ${{ inputs.branch }}
-      git push --force-with-lease --verbose           --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
-      git push --force-with-lease --verbose           --tags ${{ inputs.remote }}
+      if ($do_dryrun)
+      {
+        git push --force-with-lease --verbose --dry-run ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose --dry-run --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose --dry-run --tags ${{ inputs.remote }}
+      }
+      else
+      {
+        git push --force-with-lease --verbose           ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose           --follow-tags ${{ inputs.remote }} ${{ inputs.branch }}
+        git push --force-with-lease --verbose           --tags ${{ inputs.remote }}
+      }
       Pop-Location


### PR DESCRIPTION
reason: GitHub Service Bug: booleans are not actual booleans, but strings with either 'true' or 'false' as value.

in depth: ${{ variable }} creates a string with the contents of the variable and does not resolve into a boolean value.
          **This is different from the documentation!**
          Hence we solve this persistent bug by comparing the stringified boolean ${{ inputs.dry-run }}
          with the string "true" to obtain an actual boolean we can use in Powershell.

for the record: The same issue has been raised to GitHub several times.
                e.g. https://github.com/actions/runner/issues/1483
